### PR TITLE
feat(#1): works

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 `tagrs` is a tool for [Rust test] tagging.
 
 **Motivation**. There was no such tool for Rust, that can run tests
-conditionally, based on tags, similarly to JUnit's [@Tag][JUnit Tag]. 
+conditionally, based on tags, similarly to JUnit's [@Tag][JUnit Tag].
 
 ## How to use
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
     let name = &input.sig.ident;
     let block = &input.block;
     let has_test_attr = input.attrs.iter().any(|attr| attr.path.is_ident("test"));
-    let current_tag = std::env::var("TTAG").unwrap_or_else(|_| "<none>".to_string());
-    let ignore_attr = if current_tag != tag {
+    let run = std::env::var("TTAG").unwrap_or_else(|_| "<none>".to_string());
+    let ignore_attr = if run != tag {
         quote! { #[ignore] }
     } else {
         quote! {}
@@ -54,10 +54,10 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
             #ignore_attr
             #[test]
             fn #name() -> anyhow::Result<()> {
-                if #current_tag != #tag {
+                if #run != #tag {
                     println!(
-                        "Test '{}' ignored due to tag mismatch: expected '{}', current '{}'",
-                        stringify!(#name), #tag, #current_tag
+                        "Test '{}' ignored due to tag mismatch: expected '{}', run '{}'",
+                        stringify!(#name), #tag, #run
                     );
                 }
                 #block
@@ -67,10 +67,10 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             #ignore_attr
             fn #name() -> anyhow::Result<()> {
-                if #current_tag != #tag {
+                if #run != #tag {
                     println!(
-                        "Test '{}' ignored due to tag mismatch: expected '{}', current '{}'",
-                        stringify!(#name), #tag, #current_tag
+                        "Test '{}' ignored due to tag mismatch: expected '{}', run '{}'",
+                        stringify!(#name), #tag, #run
                     );
                 }
                 #block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,19 +63,8 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #block
             }
         }
-    } else {
-        quote! {
-            #ignore_attr
-            fn #name() -> anyhow::Result<()> {
-                if #run != #tag {
-                    println!(
-                        "Test '{}' ignored due to tag mismatch: expected '{}', run '{}'",
-                        stringify!(#name), #tag, #run
-                    );
-                }
-                #block
-            }
-        }
+    } else { 
+        panic!("Tag {} should be used with #[test]", tag);
     };
     gen.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
     let block = &input.block;
     let has_test_attr = input.attrs.iter().any(|attr| attr.path.is_ident("test"));
     let run = std::env::var("TTAG").unwrap_or_else(|_| "<none>".to_string());
-    let ignore_attr = if run != tag {
+    let ignore_attr = if run != tag && run != "<none>" {
         quote! { #[ignore] }
     } else {
         quote! {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #block
             }
         }
-    } else { 
+    } else {
         panic!("Tag {} should be used with #[test]", tag);
     };
     gen.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let name = &input.sig.ident;
     let block = &input.block;
-    let has_test_attr = input.attrs.iter().any(|attr| attr.path.is_ident("test"));
+    let has_test_attr =
+        input.attrs.iter().any(|attr| attr.path.is_ident("test"));
     let run = std::env::var("TTAG").unwrap_or_else(|_| "<none>".to_string());
     let ignore_attr = if run != tag && run != "<none>" {
         quote! { #[ignore] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,6 @@ pub fn tag(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {}
     };
-    println!("Current Tag: {}", tag);
-    println!("Run Tag: {}", current_tag);
     let gen = if has_test_attr {
         quote! {
             #ignore_attr

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,38 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#[cfg(test)]
+mod tests {
+    use tagrs::tag;
+
+    #[tag("fast")]
+    #[test]
+    fn runs_fast() -> Result<()> {
+        assert_eq!(1 + 1, 2);
+        Ok(())
+    }
+
+    #[tag("slow")]
+    #[test]
+    fn runs_slow() -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
closes #1 
History:
- **feat(#1): #[ignore]**
- **feat(#1): no print**
- **feat(#1): run**
- **feat(#1): panice**
- **feat(#1): trail off**
- **feat(#1): run all if none**
- **feat(#1): clean**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a mechanism for conditionally running tests in Rust based on tags, similar to JUnit's tagging system. It adds functionality to ignore tests that do not match the specified tag and updates the README with relevant instructions.

### Detailed summary
- Updated `README.md` to explain the motivation behind the tool.
- In `src/lib.rs`, added logic to check for the `test` attribute and handle tag-based test ignoring.
- Enhanced the test output message for clarity on tag mismatches.
- Added a license block and test cases in `tests/integration_tests.rs` for `fast` and `slow` tags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->